### PR TITLE
Fix: Do not drop columns with 0 planktons in that class #16

### DIFF
--- a/R/NNLS_MF_Final.R
+++ b/R/NNLS_MF_Final.R
@@ -27,7 +27,8 @@ NNLS_MF_Final <- function(Fn, S, S_Chl, cm){
   C_new2 <-t(RcppML::nnls(crossprod(t(Weight_error(Fn, cm))), b,cd_maxit = 1000,cd_tol =1e-10 ))
   C_new2 <- as.matrix(C_new2)
   Cn.s2 <- rowSums(C_new2)
-  Cn2 <- C_new2/Cn.s2
+  Cn.s2_safe <- ifelse(Cn.s2 == 0, 1, Cn.s2)
+  Cn2 <- C_new2 / Cn.s2_safe
   Cn2 <- as.matrix(Cn2)
   Cn2 <- Cn2 * S_Chl
   colnames(Cn2) <- rownames(Fn)

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -37,10 +37,18 @@ simulated_annealing <- function(S,
   if (is.null(Fmat)) {
     Fmat <- phytoclass::Fm
   }
-
+  
+  if (!is.matrix(Fmat)){
+    Fmat <- as.matrix(Fmat)
+  }
+    
   if (is.data.frame(S)){
   char_cols <- sapply(S, is.character)
   S <- S[, !char_cols]}
+  
+  if (!is.matrix(S)){
+    S <- as.matrix(S)
+  }
 
   if (do_matrix_checks) {
     L <- Matrix_checks(as.matrix(S), as.matrix(Fmat))


### PR DESCRIPTION
In the original code, division by the row sums of C_new2 was performed directly, which could cause NaN values if any row sum was zero. I fixed this by replacing zero row sums with 1 before division, ensuring that rows with zero sum remain zero and no NaN values are produced.