### PR TITLE
rename clustering param minClusterSize -> minSamplesPerCluster #24

### DIFF
--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -37,10 +37,18 @@ simulated_annealing <- function(S,
   if (is.null(Fmat)) {
     Fmat <- phytoclass::Fm
   }
-
+  
+  if (!is.matrix(Fmat)){
+    Fmat <- as.matrix(Fmat)
+  }
+    
   if (is.data.frame(S)){
   char_cols <- sapply(S, is.character)
   S <- S[, !char_cols]}
+  
+  if (!is.matrix(S)){
+    S <- as.matrix(S)
+  }
 
   if (do_matrix_checks) {
     L <- Matrix_checks(as.matrix(S), as.matrix(Fmat))


### PR DESCRIPTION
Renamed the minClusterSize parameter to minSamplesPerCluster in the Cluster() function and its documentation for improved clarity and consistency.

Also updated:

1. R/Cluster.R
2. man/Cluster.Rd
3. vignettephytoclass_vigenette.Rmd

Closes #24
