### PR TITLE
Fix: Rename param minClusterSize -> minSamplePerCluster and Bound check on minSamplePerCluster

### DIFF
--- a/R/Cluster.R
+++ b/R/Cluster.R
@@ -1,7 +1,7 @@
 #' Cluster things
 #'
 #' @param Data S (sample) matrix
-#' @param min_cluster_size the minimum size required for a cluster
+#' @param minSamplesPerCluster the minimum number of samples required for a cluster
 #'
 #' @return A named list of length two. The first element "cluster.list"
 #'  is a list of clusters, and the second element "cluster.plot" the 
@@ -12,7 +12,7 @@
 #' Cluster.result <- Cluster(Sm, 14)
 #' Cluster.result$cluster.list
 #' plot(Cluster.result$cluster.plot)
-Cluster <- function(Data, min_cluster_size) {
+Cluster <- function(Data, minSamplesPerCluster) {
   
   standardise <- function(Data) {
     b <- Data
@@ -42,12 +42,12 @@ Cluster <- function(Data, min_cluster_size) {
   mv.hclust <- stats::hclust(mscluster, method = "ward.D2")
 
   ev.clust <- Data
-  # Change the minClusterSize argument below to change the number of clusters.
+  # Change the minSamplesPerCluster argument below to adjust how many samples 
   # You might want to play around with it if you want ~ 6 clusters.
   # You could try setting it at 1/6th of the total sample number :)
   dynamicCut <- dynamicTreeCut::cutreeDynamic(mv.hclust,
     cutHeight = 70,
-    minClusterSize = min_cluster_size,
+    minClusterSize = minSamplesPerCluster,
     method = "hybrid",
     distM = as.matrix(stats::dist(ndf, method = "euclidean")), 
     deepSplit = 4,

--- a/R/Cluster.R
+++ b/R/Cluster.R
@@ -14,6 +14,22 @@
 #' plot(Cluster.result$cluster.plot)
 Cluster <- function(Data, minSamplesPerCluster) {
   
+  number_of_Samples <- nrow(Data)
+  number_of_Features <- ncol(Data) - 1 
+  
+  # Stop if minSamplesPerCluster is less than the number of features
+  if (minSamplesPerCluster < number_of_Features) {
+    stop(sprintf("minSamplesPerCluster (%d) cannot be less than number of features/pigments (%d).", 
+                 minSamplesPerCluster, number_of_Features))
+  }
+  
+  # Stop if minSamplesPerCluster exceeds half the total number of samples
+  maxAllowed <- floor(number_of_Samples / 2)
+  if (minSamplesPerCluster > maxAllowed) {
+    stop(sprintf("minSamplesPerCluster (%d) cannot be greater than half of total samples (%d).", 
+                 minSamplesPerCluster, maxAllowed))
+  }
+  
   standardise <- function(Data) {
     b <- Data
     b <- b[, 1:ncol(b) - 1]

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -37,10 +37,18 @@ simulated_annealing <- function(S,
   if (is.null(Fmat)) {
     Fmat <- phytoclass::Fm
   }
-
+  
+  if (!is.matrix(Fmat)){
+    Fmat <- as.matrix(Fmat)
+  }
+    
   if (is.data.frame(S)){
   char_cols <- sapply(S, is.character)
   S <- S[, !char_cols]}
+  
+  if (!is.matrix(S)){
+    S <- as.matrix(S)
+  }
 
   if (do_matrix_checks) {
     L <- Matrix_checks(as.matrix(S), as.matrix(Fmat))

--- a/man/Cluster.Rd
+++ b/man/Cluster.Rd
@@ -4,12 +4,12 @@
 \alias{Cluster}
 \title{Cluster things}
 \usage{
-Cluster(Data, min_cluster_size)
+Cluster(Data, minSamplesPerCluster)
 }
 \arguments{
 \item{Data}{S (sample) matrix}
 
-\item{min_cluster_size}{the minimum size required for a cluster}
+\item{minSamplesPerCluster}{the minimum number of samples required for a cluster}
 }
 \value{
 A named list of length two. The first element "cluster.list"

--- a/vignettes/phytoclass-vignette.Rmd
+++ b/vignettes/phytoclass-vignette.Rmd
@@ -122,7 +122,7 @@ Results$Figure
 ### Example with clustering
 
 ```{r message=FALSE}
-Clust1 <- Cluster(Sm, min_cluster_size = 14)$cluster.list[[1]]
+Clust1 <- Cluster(Sm, minSamplesPerCluster = 14)$cluster.list[[1]]
 # Remove the cluster column/label
 Clust1$Clust <- NULL
 


### PR DESCRIPTION
This PR addresses issues #24 and #25 by:

1. Renaming the clustering parameter minClusterSize to minSamplesPerCluster across relevant code files and documentation.
2. Adding boundary checks on minSamplesPerCluster to ensure it is not less than the number of features and not greater than half of total samples.

Changes include:

1. Updated function parameter name in R/Cluster.R.
2. Modified documentation in man/Cluster.Rd.
3. Updated examples and explanations in the vignette vignettes/phytoclass-vignette.Rmd.
4. Added bound checks on minSamplesPerCluster inside the Cluster function.


```
> Cluster(S, 5)
Error in Cluster(S, 5) : 
  minSamplesPerCluster (5) cannot be less than number of features/pigments (13).
Called from: Cluster(S, 5)
Browse[1]> Q
> Cluster(S, 100)
Error in Cluster(S, 100) : 
  minSamplesPerCluster (100) cannot be greater than half of total samples (14).
Called from: Cluster(S, 100)
```


Closes #24
Closes #25

