### PR TITLE
Fix: Better error message for missing min_max values specified by F-matrix

### DIFF
--- a/R/Default_min_max.R
+++ b/R/Default_min_max.R
@@ -26,9 +26,18 @@ Default_min_max <- function(min_max, Fmat, place){
     CName[[length(CName)+1]] <- colnames(Fmat)[k[[i]][,2]]
   }
   
+  
+  # Find indices in min_max matching each taxa-pigment pair;
+  # throw error if any pair is missing in min_max
   vecs <- vector()
   for (i in 1:length(k)){
-    vecs[[length(vecs)+1]]<-which(RName[[i]] == min_max[,1] & CName[[i]] == min_max[,2])
+    idx <- which(RName[[i]] == min_max[,1] & CName[[i]] == min_max[,2])
+    if (length(idx) == 0) {
+      stop(paste0("Your F matrix includes an unexpected taxa-pigment pair for ", 
+                  RName[[i]], " - ", CName[[i]], 
+                  ". This pair is not in the min_max matrix."))
+    }
+    vecs[[length(vecs)+1]] <- idx
   }
   
   min <- min_max[vecs,3]


### PR DESCRIPTION
This PR enhances the error messaging in the Default_min_max function to provide clearer, more informative feedback when the F matrix contains taxa-pigment pairs not present in the min_max reference matrix.

- Added explicit error checks to identify missing taxa-pigment pairs.
- Improved error messages specify exactly which pair is missing, helping users quickly identify and fix data inconsistencies.

Example:
```
> Fmat
                           Chl_c3  Per   Fuco   Neox   Pra   Viol   X19hex   Allo   Zea   Chl_b
Chlorophytes           0       0       0        1         0      1         0           0        1     1
Prasinophytes          0       0       0        1         1      1         0           0        1     1
Cryptophytes           0       0       0        0         0      0         0           1        0     0
Diatoms-B               1       0       1        0         0      0         0           0        0     0
Dinoflagellates-A     0       1       0        0        0      0         0           0        0     0
Haptophytes            1       0       1        0        0      0         1           0        0     0

> result <- simulated_annealing(S, Fmat = Fmat, do_matrix_checks = FALSE, niter = 5)
Error in Default_min_max(phytoclass::min_max, Fmat[, 1:ncol(Fmat) - 1],  : 
  Your F matrix includes an unexpected taxa-pigment pair for Diatoms-B - Chl_c3. This pair is not in the min_max matrix.
Called from: Default_min_max(phytoclass::min_max, Fmat[, 1:ncol(Fmat) - 1], 
    place)
```

Closes #23 
