### PR TITLE
Fix: ME2.qmd to run with custom ME2 dataset

### DIFF
--- a/tests/integration/ME2.qmd
+++ b/tests/integration/ME2.qmd
@@ -59,6 +59,10 @@ rownames(taxa_abundance) <- sample_names
 knitr::kable(taxa_abundance, caption = "Taxa estimation with sample names")
 
 ```
+```{r figure-output, fig.width=7, fig.height=5}
+# Plot the results figure
+result$Figure
+```
 
 "Error in rowSums(Fmat) : 'x' must be numeric."
 

--- a/tests/integration/ME2.qmd
+++ b/tests/integration/ME2.qmd
@@ -12,21 +12,52 @@ library(here)
 ```
 
 ```{R}
-# sample matrix
-S_matrix <- read.csv(here("tests/integration/ME2-S.csv"))
+# Load and prepare S_matrix
+S_df <- read.csv(here("tests/integration/ME2-S.csv"))
+sample_names <- S_df[[1]]
+S_matrix <- S_df[, -1]
 ```
 
 ```{R}
-# pigment-taxa occurrence matrix (specific to an oceanographic region)
-F_matrix <- read.csv(here("tests/integration/ME2-F.csv"))
+# Load and prepare F_matrix
+F_df <- read.csv(here("tests/integration/ME2-F.csv"), row.names = 1)
+F_matrix <- as.matrix(F_df)  # Keeps taxa as rownames
 ```
 
 ```{R}
-phytoclass::simulated_annealing(
+# Build custom min-max matrix
+k <- which(F_matrix > 0, arr.ind = TRUE)
+taxa    <- rownames(F_matrix)[k[, 1]]
+pigment <- colnames(F_matrix)[k[, 2]]
+
+min_max_matrix <- data.frame(
+  class   = taxa,
+  pigment = pigment,
+  min     = rep(0.001, length(taxa)),
+  max     = rep(1, length(taxa)),
+  stringsAsFactors = FALSE
+)
+```
+
+```{R}
+
+# Run model
+result <- phytoclass::simulated_annealing(
   S_matrix,
   Fmat = F_matrix,
-  user_defined_min_max = min_max_matrix
+  user_defined_min_max = min_max_matrix,
+  niter = 30
 )
+```
+
+```{R}
+# Add sample names back to output
+taxa_abundance <- result[[4]]
+rownames(taxa_abundance) <- sample_names
+
+# Display results
+knitr::kable(taxa_abundance, caption = "Taxa estimation with sample names")
+
 ```
 
 "Error in rowSums(Fmat) : 'x' must be numeric."


### PR DESCRIPTION
Fix: Update ME2 dataset handling in ME2.qmd
    - Set row.names = 1 while loading both ME2-S.csv and ME2-F.csv to correctly preserve sample and taxa names.
    - Added logic to generate a custom min_max matrix dynamically based on non-zero entries in the ME2-F matrix, since the ME2 dataset does not align with the default min_max.
    - Ensures sample names are retained in the output table.

