### PR TITLE
Add seed-based unit tests and ensure reproducibility in simulated_annealing()

### DIFF
--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -1,0 +1,29 @@
+name: testthat-only
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  testthat:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            devtools
+            testthat
+          needs: test
+
+      - name: Run testthat tests
+        run: Rscript -e 'devtools::test()'

--- a/R/NNLS_MF_Final.R
+++ b/R/NNLS_MF_Final.R
@@ -50,7 +50,7 @@ NNLS_MF_Final <- function(Fn, S, S_Chl, cm){
   #  -  no visible binding for global variable
   vals <-  NULL
   .data <- NULL
-  PLE <- tidyr::pivot_longer(data = k, cols = cn, names_to = 'names', values_to = 'vals' )
+  PLE <- tidyr::pivot_longer(data = k, cols = tidyselect::all_of(cn), names_to = 'names', values_to = 'vals')
   colorBlindGrey8   <- c("#999999", "#E69F00", "#56B4E9", "#009E73",
                          "#F0E442", "#0072B2", "#D55E00", "#CC79A7","#009E73","#001E73","#013E73")
   gr <- colnames(PLE)[[1]]

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -35,7 +35,14 @@ simulated_annealing <- function(S,
                                 niter = 500,
                                 step = 0.009,
                                 weight.upper.bound = 30, 
-                                verbose = TRUE){
+                                verbose = TRUE,
+                                seed = NULL){
+  
+  if (!is.null(seed)) {
+    set.seed(seed)
+  }
+  
+  
   if (is.null(Fmat)) {
     Fmat <- phytoclass::Fm
   }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(phytoclass)
+
+test_check("phytoclass")

--- a/tests/testthat/test-simulated_annealing-randomness.R
+++ b/tests/testthat/test-simulated_annealing-randomness.R
@@ -1,0 +1,22 @@
+test_that("simulated_annealing output changes with different seeds", {
+  Sm <- phytoclass::Sm
+  Fm <- phytoclass::Fm
+  
+  out1 <- simulated_annealing(Sm, Fm, niter = 10, seed = 1234, verbose = FALSE)
+  out2 <- simulated_annealing(Sm, Fm, niter = 10, seed = 4567, verbose = FALSE)
+  
+  # Compare class abundances
+  expect_false(
+    isTRUE(all.equal(out1$`Class abundances`, out2$`Class abundances`, tolerance = 1e-10))
+  )
+  # Compare RMSE values
+  expect_false(
+    isTRUE(all.equal(out1$RMSE, out2$RMSE, tolerance = 1e-10))
+  )
+  
+  # Compare MAE vector
+  expect_false(
+    isTRUE(all.equal(out1$MAE, out2$MAE, tolerance = 1e-10))
+  )
+  
+})

--- a/tests/testthat/test-simulated_annealing-reproducible.R
+++ b/tests/testthat/test-simulated_annealing-reproducible.R
@@ -1,0 +1,18 @@
+test_that("simulated_annealing output is the same with same seeds", {
+  Sm <- phytoclass::Sm
+  Fm <- phytoclass::Fm
+  
+  out1 <- simulated_annealing(Sm, Fm, niter = 10, seed = 1234, verbose = FALSE)
+  out2 <- simulated_annealing(Sm, Fm, niter = 10, seed = 1234, verbose = FALSE)
+  
+  # These should match exactly
+  expect_true(
+    isTRUE(all.equal(out1$`Class abundances`, out2$`Class abundances`, tolerance = 1e-10))
+  )
+  expect_true(
+    isTRUE(all.equal(out1$RMSE, out2$RMSE, tolerance = 1e-10))
+  )
+  expect_true(
+    isTRUE(all.equal(out1$MAE, out2$MAE, tolerance = 1e-10))
+  )
+})


### PR DESCRIPTION
This PR addresses the following:

1. Adds testthat infrastructure and tests to check the reproducibility of simulated_annealing() results based on random seeds:
      - Confirms that identical seeds yield identical outputs (test-simulated_annealing-reproducible.R).
      - Confirms that different seeds yield different results (test-simulated_annealing-randomness.R).

2. Modifies **simulated_annealing()** to ensure consistent behavior when seed is provided  resolving issue #34 

3. Updates **NNLS_MF_Final.R** to reflect changes required for the version bump, eliminating a warning during test checks.

4. Adds a GitHub Action workflow (testthat-only) to run unit tests on push/PR to main or master branches as instructed on #42 

closes #34 
closes #34 