### PR TITLE
Simplify `Steepest_Desc()`

### DIFF
--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -211,10 +211,10 @@ simulated_annealing <- function(
     if (verbose) {
       message(
         paste(
-          "Iterations: ", k, "of", niter,
-          "\nCurrent error: ", round(f_c_err, 4),
+          "Iterations:        ", k, "of", niter,
+          "\nCurrent error:     ", round(f_c_err, 4),
           "\nNeighbour's error: ", round(f_n_err, 4),
-          "\nTemperature (%): ", round(Temp * 100, 2), "\n"
+          "\nTemperature (%):   ", round(Temp * 100, 2), "\n"
           )
         )
     }

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -72,29 +72,23 @@ simulated_annealing <- function(
   place <- which(Fmat[, -ncol(Fmat)] > 0)
   
   if (is.null(user_defined_min_max)) {
-    min_max <- Default_min_max(phytoclass::min_max, Fmat[, -ncol(Fmat)], place)
-    # K <- Default_min_max(phytoclass::min_max, Fmat[, -ncol(Fmat)], place)
+    min_max_mat <- Default_min_max(phytoclass::min_max, Fmat[, -ncol(Fmat)], place)
   } else {
-    # K <- Default_min_max(user_defined_min_max,Fmat[, -ncol(Fmat)], place)
-    min_max <- Default_min_max(user_defined_min_max,Fmat[, -ncol(Fmat)], place)
+    min_max_mat <- Default_min_max(user_defined_min_max,Fmat[, -ncol(Fmat)], place)
   }
-    # if (length(min.val) != length(place)) {
+    # if (length(min_max_mat[[1]]) != length(place)) {
     #   message(paste0("\nNumber of rows for user_defined_min_max = ", 
-    #                  length(min.val)))
+    #                  length(min_max_mat[[1]])))
     #   message(paste0("Length of place = ", length(place)))
     #   stop("\nThese do not match.")
     # }
-  
-  # min.val <- K[[1]]
-  # max.val <- K[[2]]
   
   # ---- start kappa condition check ---- #
 
   condition.test <- Condition_test(
     S[, -ncol(S)], 
     Fmat[, -ncol(Fmat)], 
-    # min.val, max.val
-    min_max[[1]], min_max[[2]]
+    min_max_mat[[1]], min_max_mat[[2]]
     )
   
   if (verbose) {
@@ -131,7 +125,7 @@ simulated_annealing <- function(
   
   # extract min and max F matrix thresholds and last column ratio
   # wrangled <- Wrangling(f_c, min.val, max.val)
-  wrangled <- Wrangling(f_c, min_max[[1]], min_max[[2]])
+  wrangled <- Wrangling(f_c, min_max_mat[[1]], min_max_mat[[2]])
   minF     <- wrangled[[1]]
   maxF     <- wrangled[[2]]
   chlv     <- wrangled[[4]]

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -211,7 +211,7 @@ simulated_annealing <- function(
     if (verbose) {
       message(
         paste(
-          "Iterations:        ", k, "of", niter,
+          "Iterations:        ", sprintf("%03d", k), "of", niter,
           "\nCurrent error:     ", round(f_c_err, 4),
           "\nNeighbour's error: ", round(f_n_err, 4),
           "\nTemperature (%):   ", round(Temp * 100, 2), "\n"

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -163,8 +163,8 @@ simulated_annealing <- function(
     f_n      <- new_neighbour[[1]]
 
     # check if ratios are out of bounds (min\max)
-    oob <- which(vectorise(f_n[, -ncol(f_n)]) < minF | 
-                 vectorise(f_n[, -ncol(f_n)]) > maxF)
+    vect <- vectorise(f_n[, -ncol(f_n)])
+    oob  <- which(vect < minF | vect > maxF) 
     
     # if new lowest neighbor has a ratio outside of bounds, will change only 
     # those ones
@@ -188,8 +188,8 @@ simulated_annealing <- function(
       f_n           <- new_neighbour[[1]]
       
       # check if ratios are out of bounds (min\max)
-      oob <- which(vectorise(f_n[, -ncol(f_n)]) < minF |
-                   vectorise(f_n[, -ncol(f_n)]) > maxF) 
+      vect <- vectorise(f_n[, -ncol(f_n)])
+      oob  <- which(vect < minF | vect > maxF) 
       
     } 
     
@@ -211,7 +211,8 @@ simulated_annealing <- function(
     if (verbose) {
       message(
         paste(
-          "Current error: ", round(f_c_err, 4),
+          "Iterations: ", k, "of", niter,
+          "\nCurrent error: ", round(f_c_err, 4),
           "\nNeighbour's error: ", round(f_n_err, 4),
           "\nTemperature (%): ", round(Temp * 100, 2), "\n"
           )


### PR DESCRIPTION
The `Steepest_Desc()` function is basically the same as `Steepest_Descent()` except that it only runs the steepest descent algorithm by giving the inputs of S matrix, F matrix and number of loops. In this update, `Steepest_Desc()` becomes a wrapper for `Steepest_Descent()` so when updates occur to `Steepest_Descent()`, it also applies to the `Steepest_Desc()`.

For `Steepest_Descent()`, unused variables are removed, and input names are updated.
- rm extra `loop` variable 
- rn `cm` to `S_weights`