### PR TITLE
Add automatic switch to Prochlorococcus function based on dvchl column

### DIFF
--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -38,6 +38,27 @@ simulated_annealing <- function(S,
                                 verbose = TRUE,
                                 seed = NULL){
   
+  # Check for dvchl/dvchla in penultimate column and use Prochlorococcus variant
+  if (is.data.frame(S)) {
+    col_names <- tolower(colnames(S))
+    penultimate_col <- col_names[length(col_names) - 1]
+    
+    if (!is.null(penultimate_col) &&
+        penultimate_col %in% c("dvchl", "dvchla")) {
+      
+        message("Detected dvchl column. Using simulated_annealing_Prochloro().")
+        
+        return(simulated_annealing_Prochloro(S = S,
+                                             Fmat = Fmat,
+                                             user_defined_min_max = user_defined_min_max,
+                                             do_matrix_checks = do_matrix_checks,
+                                             niter = niter,
+                                             step = step,
+                                             weight.upper.bound = weight.upper.bound,
+                                             verbose = verbose))
+    }
+  }
+  
   if (!is.null(seed)) {
     set.seed(seed)
   }

--- a/R/simulated_annealing.R
+++ b/R/simulated_annealing.R
@@ -38,26 +38,6 @@ simulated_annealing <- function(S,
                                 verbose = TRUE,
                                 seed = NULL){
   
-  # Check for dvchl/dvchla in penultimate column and use Prochlorococcus variant
-  if (is.data.frame(S)) {
-    col_names <- tolower(colnames(S))
-    penultimate_col <- col_names[length(col_names) - 1]
-    
-    if (!is.null(penultimate_col) &&
-        penultimate_col %in% c("dvchl", "dvchla")) {
-      
-        message("Detected dvchl column. Using simulated_annealing_Prochloro().")
-        
-        return(simulated_annealing_Prochloro(S = S,
-                                             Fmat = Fmat,
-                                             user_defined_min_max = user_defined_min_max,
-                                             do_matrix_checks = do_matrix_checks,
-                                             niter = niter,
-                                             step = step,
-                                             weight.upper.bound = weight.upper.bound,
-                                             verbose = verbose))
-    }
-  }
   
   if (!is.null(seed)) {
     set.seed(seed)
@@ -84,6 +64,25 @@ simulated_annealing <- function(S,
     L <- Matrix_checks(as.matrix(S), as.matrix(Fmat))
     S <- as.matrix(L[[1]])
     Fmat <- as.matrix(L[[2]])
+  }
+  
+  # Check for dvchl/dvchla
+  col_names <- tolower(colnames(S))
+  penultimate_col <- col_names[length(col_names) - 1]
+
+  if (!is.null(penultimate_col) &&
+      penultimate_col %in% c("dvchl", "dvchla")) {
+
+    message("Detected dvchl column. Using simulated_annealing_Prochloro().")
+
+    return(simulated_annealing_Prochloro(S = S,
+                                         Fmat = Fmat,
+                                         user_defined_min_max = user_defined_min_max,
+                                         do_matrix_checks = do_matrix_checks,
+                                         niter = niter,
+                                         step = step,
+                                         weight.upper.bound = weight.upper.bound,
+                                         verbose = verbose))
   }
   
   S_Chl <- S[, ncol(S)]

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,6 +22,9 @@ The main function is 'Simulated annealing'. This can be used in conjuction with 
 When setting up your matrices, it is important to ensure that pigments are in the same order in the Sm and Fm matrices. Chlorophyll a must be the final column.
 
 There is a separate function when Divinyl chlorophyll a and Prochlorococcus are used. Here Divinyl chlorophyll a must be the 2nd to last column (see 'Fp').
+Note: If dvchl is detected as the second-to-last column in your input matrix, 
+the simulated_annealing() function will automatically call the 
+Prochlorococcus-optimized version (simulated_annealing_Prochloro()).
 
 The 'Steepest Descent'function is similar to that of CHEMTAX, and is unconstrained by minimum and maximum values, unlike the simualted annealing function. I would use this with more caution.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ the final column.
 There is a separate function when Divinyl chlorophyll a and
 Prochlorococcus are used. Here Divynl chlorophyll a must be the 2nd to
 last column (see ‘Fp’).
+Note: If dvchl is detected as the second-to-last column in your input matrix, 
+the simulated_annealing() function will automatically call the 
+Prochlorococcus-optimized version (simulated_annealing_Prochloro()).
 
 The ’Steepest Descent’function is similar to that of CHEMTAX, and is
 unconstrained by minimum and maximum values, unlike the simualted


### PR DESCRIPTION
This PR adds automatic detection of dvchl as the second-to-last column in the input matrix S. When detected, simulated_annealing() redirects to the simulated_annealing_Prochloro() function, optimized for Prochlorococcus data.

The README has been updated with a brief note explaining this behavior under matrix setup instructions.

Closes #53 